### PR TITLE
feat: add ads.txt file for Google AdSense configuration

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9063401338616510, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request adds a new entry to the `ads.txt` file to authorize a Google advertising publisher.

* Added `google.com, pub-9063401338616510, DIRECT, f08c47fec0942fa0` to `ads.txt` to allow direct advertising via Google for the specified publisher.